### PR TITLE
Added way to deal with films that do not have studio info

### DIFF
--- a/disney_collection.py
+++ b/disney_collection.py
@@ -12,12 +12,15 @@ baseurl = (server["PLEX_URL"])
 token = (server["TOKEN"])
 films = (server["FILMSLIBRARY"])
 plex = PlexServer(baseurl, token)
-movies_section = plex.library.section('films')
+movies_section = plex.library.section(films)
 added = movies_section.search(sort='titleSort')
 
+for movie in added:
+    print('%s (%s)' % (movie.title, movie.studio))
 
-for movie in added: 
-    print('%s (%s)' % (movie.title, movie.studio)) 
-    if "Disney" in movie.studio:
-        movie.addCollection('Disney')
-  
+    try:
+        if "Disney" in movie.studio:
+            movie.addCollection('Disney')
+    # Skip movie if there is no studio info
+    except TypeError:
+        continue


### PR DESCRIPTION
This fixes an issue where the script would get stuck if it ran into a film that didn't have studio info. I also removed accidental apostrophes around the films var on line 15 which was preventing it from being used correctly.