### PR TITLE
Minor bug fixes

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04    
     env:      
       DOCKER_REGISTRY: hub.docker.com
-      DOCKER_IMAGE: jkirkcaldy/plex-utills      
+      DOCKER_IMAGE: dtayme/plex-utills      
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}               
     steps:    
@@ -26,7 +26,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: jkirkcaldy/plex-utills
+        images: dtayme/plex-utills
 
     - name: build and push
       uses: docker/build-push-action@v2

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04    
     env:      
       DOCKER_REGISTRY: hub.docker.com
-      DOCKER_IMAGE: dtayme/plex-utills      
+      DOCKER_IMAGE: fognetx/plex-utills      
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}               
     steps:    
@@ -26,7 +26,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: dtayme/plex-utills
+        images: fognetx/plex-utills
 
     - name: build and push
       uses: docker/build-push-action@v2

--- a/app/api.py
+++ b/app/api.py
@@ -401,12 +401,13 @@ def help():
                 newdir = PurePosixPath('/films', *p.parts[1:])
                 log.debug(newdir)
             elif config[0].manualplexpath == 1:
-                newdir = re.sub(config[0].manualplexpathfield, '/films', i.media[0].parts[0].file)
+                newdir = re.sub(config[0].manualplexpathfield, '/films/', i.media[0].parts[0].file, 1)
             else:
-                newdir = re.sub(config[0].plexpath, '/films', i.media[0].parts[0].file)
+                newdir = re.sub(config[0].plexpath, '/films/', i.media[0].parts[0].file, 1)
         except:
             newdir = 'Can not be converted'
         log.debug(newdir)
+        exists = 'False'
         if os.path.exists(newdir) == True:
             exists = 'True'
             log.debug("PATH EXISTS")

--- a/app/api.py
+++ b/app/api.py
@@ -357,6 +357,7 @@ def help():
     import shutil 
     from pathlib import PureWindowsPath, PurePosixPath
     file_paths = './app/static/img/tmp/'
+    localexists = 'False'
     config = Plex.query.filter(Plex.id == '1')
     plexserver = PlexServer(config[0].plexurl, config[0].token)
     lib = config[0].filmslibrary.split(',')
@@ -406,8 +407,7 @@ def help():
                 newdir = re.sub(config[0].plexpath, '/films/', i.media[0].parts[0].file, 1)
         except:
             newdir = 'Can not be converted'
-        log.debug(newdir)
-        localexists = 'False'
+        log.debug(newdir)        
         if os.path.exists(newdir) == True:
             localexists = 'True'
             log.debug("PATH EXISTS")

--- a/app/api.py
+++ b/app/api.py
@@ -358,6 +358,12 @@ def help():
     from pathlib import PureWindowsPath, PurePosixPath
     file_paths = './app/static/img/tmp/'
     localexists = 'False'
+    plex_filepath = ''
+    filmtitle = ''
+    newdir = ''
+    backup_poster = ''
+    current_poster = ''
+    version = ''
     config = Plex.query.filter(Plex.id == '1')
     plexserver = PlexServer(config[0].plexurl, config[0].token)
     lib = config[0].filmslibrary.split(',')

--- a/app/api.py
+++ b/app/api.py
@@ -407,14 +407,14 @@ def help():
         except:
             newdir = 'Can not be converted'
         log.debug(newdir)
-        exists = 'False'
+        localexists = 'False'
         if os.path.exists(newdir) == True:
-            exists = 'True'
+            localexists = 'True'
             log.debug("PATH EXISTS")
         else:
-            exists = 'False'
+            localexists = 'False'
             log.debug("PATH DOES NOT EXIST")
-    return render_template('help.html', exists=exists, pagetitle='Help', plex=config, plex_filepath=plex_filepath, filmtitle=filmtitle, newdir=newdir, mpath=mpath, backup_poster=backup_poster, current_poster=current_poster, pageheadding='Help', version=version)
+    return render_template('help.html', exists=localexists, pagetitle='Help', plex=config, plex_filepath=plex_filepath, filmtitle=filmtitle, newdir=newdir, mpath=mpath, backup_poster=backup_poster, current_poster=current_poster, pageheadding='Help', version=version)
 
 
 @app.route('/webhook',methods=['POST'])

--- a/app/module.py
+++ b/app/module.py
@@ -342,9 +342,9 @@ def scan_files(config, i, plex):
         logger.debug('path is: '+str(p1))
         file = PurePosixPath('/films', *p.parts[1:])
     elif config[0].manualplexpath == 1:
-        file = re.sub(config[0].manualplexpathfield, '/films', i.media[0].parts[0].file)
+        file = re.sub(config[0].manualplexpathfield, '/films/', i.media[0].parts[0].file,1)
     else:
-        file = re.sub(config[0].plexpath, '/films', i.media[0].parts[0].file)
+        file = re.sub(config[0].plexpath, '/films/', i.media[0].parts[0].file,1)
     logger.debug(file)
     try:
         m = MediaInfo.parse(file, output='JSON')

--- a/app/routes.py
+++ b/app/routes.py
@@ -23,7 +23,7 @@ def get_version():
     with open('./version') as f: s = f.read()
     return s
 version = get_version()
-@app.before_first_request
+#@app.before_first_request
 def update_plex_path():
 
     import requests

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
     plex-utills:
-        image: jkirkcaldy/plex-utills
+        image: dtayme/plex-utills
         container_name: plex-utills
         restart: unless-stopped
         volumes: 


### PR DESCRIPTION
- Fixed regex replace to only replace the first element matching plex path
- Fixed help page from throwing 500 errors when a 4K movie doesn't exist in database

## Summary by Sourcery

Fix regex replacement to only affect the first match and resolve 500 errors on the help page when a 4K movie is missing. Update Docker image references in CI workflow and docker-compose configuration.

Bug Fixes:
- Fix regex replace to only replace the first occurrence of a matching Plex path.
- Fix help page from throwing 500 errors when a 4K movie doesn't exist in the database.

CI:
- Update Docker image references in GitHub Actions workflow from 'jkirkcaldy/plex-utills' to 'fognetx/plex-utills'.

Deployment:
- Change Docker image reference in docker-compose.yaml from 'jkirkcaldy/plex-utills' to 'dtayme/plex-utills'.